### PR TITLE
Add CausalLayer MCP to Audit, Observability, and Cost Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 - [Portkey](https://portkey.ai/) - AI gateway with unified API for 250+ LLMs, request tracing, semantic caching, load balancing, and budget controls.
 - [Evidently AI](https://www.evidentlyai.com/) - Open-source ML and LLM monitoring. Detects data and model drift, generates monitoring reports, and evaluates LLM output quality.
 - [WhyLabs AI Observatory](https://whylabs.ai/) - AI observability platform monitoring LLM applications for drift, data quality issues, and policy violations in production.
+- [CausalLayer MCP](https://github.com/smq9sn5jck-coder/causallayer-mcp) - Deterministic AI liability attribution engine exposed as a remote MCP server. Given a structured incident, returns a CausalCertificateV1: a signed, hash-chained, Bitcoin-anchored receipt allocating fault between AI vendor, deployer, and end-user. Four-factor scoring, Shapley-inspired multi-agent attribution, and jurisdiction-aware regulatory mapping (EU AI Act, NIST AI RMF, AU AI Ethics).
 
 ---
 


### PR DESCRIPTION
CausalLayer is a deterministic AI liability attribution engine exposed as a remote MCP server. It returns signed, Bitcoin-anchored receipts allocating fault between AI agents in multi-party incidents.

Relevant to this list because it provides:
- Immutable audit trail (hash-chained certificates)
- Deterministic attribution (no LLM-based reasoning)
- Regulatory mapping (EU AI Act, NIST AI RMF, AU AI Ethics)
- Cost allocation across responsible parties