### PR TITLE
Add Tuning Engines to agent governance resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 - [Helicone](https://github.com/Helicone/helicone) - Open-source LLM observability proxy. Request logging, cost tracking, caching, and rate limiting via a single proxy endpoint. Self-hostable.
 - [Weights and Biases Weave](https://wandb.ai/site/weave) - Tracing and evaluation for LLM applications with strong integrations for LangChain, LlamaIndex, OpenAI, and Anthropic.
 - [Portkey](https://portkey.ai/) - AI gateway with unified API for 250+ LLMs, request tracing, semantic caching, load balancing, and budget controls.
+- [Tuning Engines](https://www.tuningengines.com/) - AI control and evidence plane for model, MCP, skill, and agent traffic. Provides governed routing, policy decisions, approval workflows, cost analytics, trace ingestion, and runtime state references.
 - [Evidently AI](https://www.evidentlyai.com/) - Open-source ML and LLM monitoring. Detects data and model drift, generates monitoring reports, and evaluates LLM output quality.
 - [WhyLabs AI Observatory](https://whylabs.ai/) - AI observability platform monitoring LLM applications for drift, data quality issues, and policy violations in production.
 


### PR DESCRIPTION
Adds Tuning Engines as an AI control and evidence plane under Audit, Observability, and Cost Control.\n\nWhy this fits the list:\n- focuses on runtime governance for model, MCP, skill, and agent traffic\n- includes policy decisions, approval workflows, cost analytics, trace ingestion, and runtime state references\n- complements the existing observability and gateway entries without changing the list structure