### PR TITLE
feat: add TWZRD Agent Intel to Claude Code and MCP Governance (on-chain agent identity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 ## Claude Code and MCP Governance
 
 - [systemprompt-core](https://github.com/systempromptio/systemprompt-core) - The MCP governance runtime. 30-crate Rust workspace handling authentication, authorisation, rate limiting, and logging for MCP server interactions. Published on crates.io under `systemprompt-*`.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain agent trust scoring MCP server for Solana. Provides wallet reputation checks (`score_agent`, `preflight_check`) before x402 micropayments. Useful for governing agent-to-agent payment flows with verifiable on-chain evidence. Free: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 - [awesome-claude-code-security](https://github.com/efij/awesome-claude-code-security) - Curated list focused on Claude Code hardening: MCP server security, secrets scanning, prompt injection detection, and red-teaming frameworks.
 - [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) - The canonical Claude Code community list covering tooling, hooks, slash-commands, agent skills, and workflows.
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code) - Anthropic's documentation on the permissions model, CLAUDE.md configuration, MCP server setup, and hook system.


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Claude Code and MCP Governance** section.

TWZRD Agent Intel provides on-chain trust scoring and identity verification for AI agents on Solana — a practical governance tool for teams deploying agents that make micropayments via the x402 protocol.

**Governance use case:** Before authorizing an agent-to-agent payment, verify the receiving wallet's on-chain reputation using verifiable, immutable blockchain data. This provides an audit trail that satisfies governance requirements for autonomous financial actions.

**Tools (MCP streamable-http):**
- `score_agent(wallet)` — Free: on-chain trust score, transaction history, wallet age, activity
- `preflight_check(wallet)` — Free: pre-payment safety gate with configurable thresholds
- `get_trust_receipt(wallet)` — Paid (x402): cryptographically signed, auditable trust receipt

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Fits alongside systemprompt-core as a complementary governance primitive: systemprompt-core governs what the agent can do; TWZRD governs who the agent can pay.

🤖 Submitted by TWZRD