### PR TITLE
feat: add Nobulex — cryptographic receipt layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 
 ## Audit, Observability, and Cost Control
 
-- [LangFuse](https://langfuse.com/) - Open-source LLM observability. Full trace capture with spans, generations, scores, and costs. Self-hostable with integrations for LangChain, LlamaIndex, OpenAI, and Anthropic SDKs.
+- [LangFuse](https://langfuse.com/)
+- [Nobulex](https://github.com/arian-gogani/nobulex) — Cryptographic receipt layer for AI agents. Ed25519-signed, JCS-canonical bilateral receipts (pre/post execution), hash-chained, independently verifiable. EU AI Act Article 12 compliance. `pip install nobulex` / `npm install @nobulex/core`. - Open-source LLM observability. Full trace capture with spans, generations, scores, and costs. Self-hostable with integrations for LangChain, LlamaIndex, OpenAI, and Anthropic SDKs.
 - [OpenTelemetry](https://opentelemetry.io/) - CNCF standard for distributed tracing, metrics, and logs. The vendor-neutral substrate for building agent observability pipelines.
 - [OpenLLMetry](https://github.com/traceloop/openllmetry) - OpenTelemetry-based instrumentation SDK for LLM applications. Traces LLM calls with standard OTel spans and integrates with existing observability stacks.
 - [Helicone](https://github.com/Helicone/helicone) - Open-source LLM observability proxy. Request logging, cost tracking, caching, and rate limiting via a single proxy endpoint. Self-hostable.


### PR DESCRIPTION
Adds Nobulex to the Audit, Observability, and Cost Control section.\n\nNobulex produces independently verifiable Ed25519-signed receipts for every agent action. Bilateral pre/post pattern, hash-chained, JCS-canonical. EU AI Act Article 12 compliance primitive.