### PR TITLE
Add ThumbGate: local-first PreToolUse enforcement engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) - NVIDIA's toolkit for adding programmable guardrails to LLM-based systems via Colang configuration language.
 - [LlamaGuard](https://github.com/meta-llama/PurpleLlama/tree/main/Llama-Guard3) - Meta's open-source content safety model for classifying LLM inputs and outputs against safety policies.
 - [Presidio](https://github.com/microsoft/presidio) - Microsoft's PII detection and anonymisation SDK. Identifies and redacts sensitive data in text before it reaches an LLM or audit log.
+- [ThumbGate](https://github.com/IgorGanapolsky/ThumbGate) - Local-first PreToolUse enforcement engine for AI coding agents. Runs in the agent's hook system to hard-block secret exfiltration, destructive deletes, and supply-chain attacks before the tool call executes. Turns thumbs-down feedback into auto-promoted prevention rules. Works with Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, and OpenCode. MIT licensed, npm installable.
 
 ---
 
@@ -104,6 +105,7 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code) - Anthropic's documentation on the permissions model, CLAUDE.md configuration, MCP server setup, and hook system.
 - [MCP Specification](https://spec.modelcontextprotocol.io/) - The Model Context Protocol specification. Understanding the protocol is prerequisite to governing it.
 - [Anthropic Cookbook](https://github.com/anthropics/anthropic-cookbook) - Reference implementations and patterns from Anthropic including agent architectures, tool use, and safety patterns.
+- [ThumbGate](https://github.com/IgorGanapolsky/ThumbGate) - PreToolUse hook-based enforcement layer that gates Claude Code's tool calls locally before execution. Hard-blocks secret exfiltration, destructive deletes, and supply-chain attacks. Self-improving rules from captured thumbs-down feedback.
 
 ---
 


### PR DESCRIPTION
## What

[ThumbGate](https://github.com/IgorGanapolsky/ThumbGate) — a local-first PreToolUse enforcement engine for AI coding agents.

## Why it belongs here

ThumbGate sits at a governance boundary not currently covered by the existing entries: the **PreToolUse hook** — between the agent's generated intent and the actual tool call execution. It runs locally on the developer's machine, no server on the enforcement path.

- **Hard-blocks** secret exfiltration, destructive deletes (`rm -rf`), and supply-chain attacks by default
- **Warn-and-log** every rule, hard-block all when `THUMBGATE_STRICT_ENFORCEMENT=1`
- Turns thumbs-down feedback into auto-promoted prevention rules (self-improving governance)
- Works with Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, and OpenCode
- MIT licensed, npm installable (`npx thumbgate init`), 4k+ monthly downloads

## Where added

Two sections:

1. **Open-Source Governance Toolkits** — as a general agent governance toolkit with a unique boundary (local PreToolUse hook, not model-layer or network egress)
2. **Claude Code and MCP Governance** — as a Claude Code-specific enforcement layer that hooks directly into the PreToolUse lifecycle

## Motivation

The April 2026 [PocketOS incident](https://www.giskard.ai/knowledge/a-cursor-ai-agent-wiped-a-production-database-in-9-seconds-excessive-agency-ai-failure) — where a Cursor agent running Claude Opus deleted a production database and all backups in 9 seconds via credential scavenging — is the exact OWASP LLM06 'Excessive Agency' failure that PreToolUse enforcement prevents. The agent performed a destructive filesystem operation (finding the root-scoped token) and then a destructive infra call (`volumeDelete`). ThumbGate would have caught both at the hook boundary.

## Format

Followed the existing entry style: `- [Name](url) - Description.` One line per section, no promotional language.