### PR TITLE
Add Certiv to Enterprise Governance Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 
 ## Enterprise Governance Platforms
 
+- [Certiv](https://certiv.ai/) - Endpoint-native runtime assurance for AI agents. Discovers agents running on the device (Claude Code, Copilot, Cursor, local models), records reasoning chains and tool calls, and enforces policy before actions execute.
 - [Credo AI](https://www.credo.ai/) - Comprehensive AI governance platform covering risk assessment, compliance mapping (EU AI Act, NIST AI RMF, ISO 42001), model cards, and ongoing monitoring across the AI lifecycle.
 - [OneTrust AI Governance](https://www.onetrust.com/solutions/ai-governance/) - Inventory, risk assessment, and compliance controls for AI systems embedded in broader data governance and privacy programmes.
 - [Lumenova AI](https://www.lumenova.ai/) - AI lifecycle governance: risk assessment, explainability monitoring, and compliance reporting focused on model transparency and regulatory evidence.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 
 ## Enterprise Governance Platforms
 
-- [Certiv](https://certiv.ai/) - Endpoint-native runtime assurance for AI agents. Discovers agents running on the device (Claude Code, Copilot, Cursor, local models), records reasoning chains and tool calls, and enforces policy before actions execute.
+- [Certiv](https://certiv.ai/?utm_source=awesome-ai-agent-governance&utm_medium=referral&utm_campaign=earned-placement) - Endpoint-native, pre-execution security and governance layer for AI agents. An endpoint agent inspects agent actions and tool calls on the device and enforces policy before they execute, with an audit trail of allowed and blocked actions.
 - [Credo AI](https://www.credo.ai/) - Comprehensive AI governance platform covering risk assessment, compliance mapping (EU AI Act, NIST AI RMF, ISO 42001), model cards, and ongoing monitoring across the AI lifecycle.
 - [OneTrust AI Governance](https://www.onetrust.com/solutions/ai-governance/) - Inventory, risk assessment, and compliance controls for AI systems embedded in broader data governance and privacy programmes.
 - [Lumenova AI](https://www.lumenova.ai/) - AI lifecycle governance: risk assessment, explainability monitoring, and compliance reporting focused on model transparency and regulatory evidence.


### PR DESCRIPTION
**Name:** Certiv
**URL:** https://certiv.ai/
**Section:** Enterprise Governance Platforms (inserted in alphabetical order)

**Description:** Endpoint-native runtime assurance for AI agents. Discovers agents running on the device (Claude Code, Copilot, Cursor, local models), records reasoning chains and tool calls, and enforces policy before actions execute.

**Why it meets the scope criteria:** This list covers runtime governance of AI agents — policy enforcement, audit trails, and access control for agents in production. Certiv operates at exactly that layer: it sits on the endpoint where coding agents and assistants actually run, captures the full audit trail of agent reasoning and tool calls, and applies pre-execution policy decisions (allow / pause / block) before an agent's action reaches the outside world. It complements the gateway- and framework-level tools already listed by covering the device-local surface (including local models) that network-side controls don't see.

**Disclosure:** I work at Certiv — submitting on behalf of the vendor, per the contributing guidelines.