### PR TITLE
Add Certiv to Enterprise Governance Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 
 ## Enterprise Governance Platforms
 
+- [Certiv](https://certiv.ai/?utm_source=awesome-ai-agent-governance&utm_medium=referral&utm_campaign=earned-placement) - Endpoint-native, pre-execution security and governance layer for AI agents. An endpoint agent inspects agent actions and tool calls on the device and enforces policy before they execute, with an audit trail of allowed and blocked actions.
 - [Credo AI](https://www.credo.ai/) - Comprehensive AI governance platform covering risk assessment, compliance mapping (EU AI Act, NIST AI RMF, ISO 42001), model cards, and ongoing monitoring across the AI lifecycle.
 - [OneTrust AI Governance](https://www.onetrust.com/solutions/ai-governance/) - Inventory, risk assessment, and compliance controls for AI systems embedded in broader data governance and privacy programmes.
 - [Lumenova AI](https://www.lumenova.ai/) - AI lifecycle governance: risk assessment, explainability monitoring, and compliance reporting focused on model transparency and regulatory evidence.


### PR DESCRIPTION
Adds a single entry for **Certiv** under *Enterprise Governance Platforms*.

**Entry**

- [Certiv](https://certiv.ai/) - Endpoint-native, pre-execution security and governance layer for AI agents. An endpoint agent inspects agent actions and tool calls on the device and enforces policy before they execute, with an audit trail of allowed and blocked actions.

**Why it fits the section / scope**

The list's scope is runtime governance of AI agents: policy enforcement, audit trails, access control, agent security. Certiv is exactly that, at a layer the list does not currently cover. Every other entry in the section governs the agent from the model/API side (proxy, gateway, or post-hoc monitoring). Certiv sits on the endpoint the agent runs on and evaluates the action before it executes, so the enforcement point is the same place as the blast radius (file writes, shell commands, tool/MCP calls), not the API boundary. That is the "policy checks that fire before any irreversible action" property the README's *Why Governance Matters* section calls for. It also covers Claude Code / MCP traffic, so if you would rather it sat under *Claude Code and MCP Governance*, that works too.

**Notes**

- Placed first in the section per the CONTRIBUTING alphabetical rule. The section does not currently read as alphabetical, so if it is ordered by something else, move it wherever you like - I have no attachment to the position.
- Description is factual and has no perf claims or marketing language, per the quality bar.
- The link carries a UTM query string so we can attribute referrals. Say the word and I will strip it to a bare https://certiv.ai/.
- Disclosure: I work at Certiv, so this is a self-submission. Happy to instead open it as a `[Submission]:` issue if you prefer that route for vendor entries.
