### PR TITLE
Add Proofpane to Enterprise Governance Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 - [HiddenLayer](https://hiddenlayer.com/) - AI detection and response platform. Monitors AI models for adversarial attacks, data extraction attempts, and policy violations.
 - [Datadog LLM Observability](https://www.datadoghq.com/product/llm-observability/) - Production monitoring for LLM applications: latency, cost, quality scoring, and trace capture integrated with existing Datadog infrastructure.
 - [Patronus AI](https://www.patronus.ai/) - Automated evaluation and monitoring for LLMs in production. Detects hallucinations, toxicity, PII leakage, and custom policy violations.
+- [Proofpane](https://proofpane.com) - Runtime governance gateway for AI coding agents (Claude Code, Cursor, Codex) and automation platforms. Enforces policy allow/deny/human-in-the-loop and DLP redaction in the execution path, and writes a hash-chained audit that exports as an offline-verifiable, Ed25519-signed evidence pack mapped to NIST AI RMF, ISO 42001, EU AI Act, GDPR, and SOC 2.
 
 ---
 


### PR DESCRIPTION
Adds one entry to **Enterprise Governance Platforms**, alongside Credo AI / OneTrust / Datadog.

**Entry:**
> [Proofpane](https://proofpane.com) - Runtime governance gateway for AI coding agents (Claude Code, Cursor, Codex) and automation platforms. Enforces policy allow/deny/human-in-the-loop and DLP redaction in the execution path, and writes a hash-chained audit that exports as an offline-verifiable, Ed25519-signed evidence pack mapped to NIST AI RMF, ISO 42001, EU AI Act, GDPR, and SOC 2.

**Why it fits the scope** (agent governance / control plane — runtime policy enforcement, audit, cost control):
- Gates AI actions in the execution path: policy allow / deny / human-in-the-loop, DLP redaction before the model, per-org and per-department cost caps.
- Governs coding agents (Cursor, Claude Code, Codex) through each vendor's official hooks (no TLS interception), plus an egress broker for API-key traffic and automation platforms (n8n, UiPath, Power Automate, Zapier).
- Maps recorded actions to controls across NIST AI RMF, ISO/IEC 42001, EU AI Act, GDPR, and SOC 2.

**Meets the quality bar** — the guidelines ask for "a free tier, open-source component, or published specification"; Proofpane has two of these:
- **Free tier:** no-signup demo — https://app.proofpane.com/login?demo=1
- **Published specification:** reference architecture under CC BY 4.0 — DOI 10.5281/zenodo.21402331, source at https://github.com/Proofpane/architecture
- Public daemon download mirror: https://github.com/Proofpane/releases
- Actively maintained (frequent commits, latest within days).

**Alternative placement:** it also fits **Claude Code and MCP Governance** (governing Claude Code / Cursor / Codex / MCP is its differentiator) — happy for you to move it there if you prefer.

**Disclosure:** I'm the author/maintainer of Proofpane. Happy to trim the description, adjust wording, or move the entry.

Supersedes / implements #18.
