### PR TITLE
Add SteerPlane to Open-Source Governance Toolkits

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A governed agent runs with least-privilege tool access, an immutable audit trail
 - [LlamaGuard](https://github.com/meta-llama/PurpleLlama/tree/main/Llama-Guard3) - Meta's open-source content safety model for classifying LLM inputs and outputs against safety policies.
 - [Presidio](https://github.com/microsoft/presidio) - Microsoft's PII detection and anonymisation SDK. Identifies and redacts sensitive data in text before it reaches an LLM or audit log.
 - [ThumbGate](https://github.com/IgorGanapolsky/ThumbGate) - Local-first PreToolUse enforcement engine for AI coding agents. Runs in the agent's hook system to hard-block secret exfiltration, destructive deletes, and supply-chain attacks before the tool call executes. Turns thumbs-down feedback into auto-promoted prevention rules. Works with Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, and OpenCode. MIT licensed, npm installable.
+- [SteerPlane](https://github.com/vijaym2k6/SteerPlane) - Open-source runtime control plane for AI agents: deterministic loop detection, per-session cost ceilings with mid-stream termination, and a hierarchical deny/allow/rate-limit policy engine, enforced via a Python decorator or an OpenAI-compatible gateway proxy. Framework integrations for LangChain, CrewAI, AutoGen, and the OpenAI Agents SDK. No model in the enforcement path. MIT licensed; `pip install steerplane` / `npm install steerplane`.
 
 ---
 


### PR DESCRIPTION
Adding SteerPlane (https://github.com/vijaym2k6/SteerPlane) to the Open-Source Governance Toolkits section.

**Disclosure**: I'm the author of this tool.

**Why it fits scope**: it's a runtime governance layer for AI agents, deterministic loop detection, per-session cost ceilings with mid-stream termination, and a hierarchical deny/allow/rate-limit policy engine, enforced before actions execute rather than reported on afterward. No model sits in the enforcement decision path.

- Open source, MIT licensed, published on PyPI and npm
- Framework integrations for LangChain, CrewAI, AutoGen, and the OpenAI Agents SDK, plus a plain Python decorator
- Actively maintained (commits within the last week)
- Core detection mechanism has a published Indian patent application (IN 202641071111 A1)

Placed at the end of the Open-Source Governance Toolkits section alongside the other kill-switch/cost-governance entries (hummbl-governance, AgentLock, ThumbGate). Happy to adjust wording or placement if it doesn't fit the list's conventions.