### PR TITLE
Add Darkmoon (GPL-3.0 autonomous AI pentest platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,4 +228,5 @@ Interactive tools that answer common governance questions without a signup. Each
 ## Related Lists
 
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) - Comprehensive directory of MCP server implementations.
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - an open source (GPL-3.0) autonomous AI penetration testing platform for web, API, Active Directory and Kubernetes.
 - [AwesomeResponsibleAI](https://github.com/AthenaCore/AwesomeResponsibleAI) - Academic and policy resources for responsible AI covering ethics, standards, and regulatory frameworks.


### PR DESCRIPTION
We would like to add Darkmoon, an open source (GPL-3.0) autonomous AI penetration testing platform covering web, API, Active Directory and Kubernetes. Thanks for maintaining this.