### PR TITLE
Add Penholder reference article to Agentic Architecture Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Interactive tools that answer common governance questions without a signup. Each
 - [awesome-agentic-patterns](https://github.com/nibzard/awesome-agentic-patterns) - Curated collection of production agent patterns including sandboxing, credential management, human-in-the-loop workflows, and multi-agent coordination.
 - [HumanLayer](https://github.com/humanlayer/humanlayer) - SDK for building human-in-the-loop workflows for AI agents. Wraps tool calls with approval gates, audit trails, and escalation paths.
 - [Lilian Weng: LLM-Powered Autonomous Agents](https://lilianweng.github.io/posts/2023-06-23-agent/) - Comprehensive survey of agent architectures including planning, memory, tool use, and oversight mechanisms.
+- [Penholder: Preventive vs Reactive AI Agent Governance](https://penholder.ai/preventive-vs-reactive-ai-agent-governance.html) - Reference article contrasting reactive (post-hoc detection) and preventive (pre-commit) approaches to agent oversight. Describes a preventive write-gate where an agent's write to a system of record is held as a durable PENDING proposal and commits only after human approval — fail-closed on conflict, with an append-only, hash-chained, tamper-evident provenance log.
 
 ---
 


### PR DESCRIPTION
### What this adds

One entry in **Agentic Architecture Patterns**, placed after "Lilian Weng: LLM-Powered Autonomous Agents" to preserve the section's alphabetical order by anchor text:

`- [Penholder: Preventive vs Reactive AI Agent Governance](https://penholder.ai/preventive-vs-reactive-ai-agent-governance.html) - Reference article contrasting reactive (post-hoc detection) and preventive (pre-commit) approaches to agent oversight. Describes a preventive write-gate where an agent's write to a system of record is held as a durable PENDING proposal and commits only after human approval — fail-closed on conflict, with an append-only, hash-chained, tamper-evident provenance log.`

### Why it fits scope

The section already collects vendor-hosted, repo-less conceptual guidance on safe agent architecture — e.g. "Anthropic: Building Effective Agents" and "Lilian Weng: LLM-Powered Autonomous Agents". This is a neutral, schema-marked reference article describing a concrete runtime-governance pattern: a pre-commit human-approval write-gate with a tamper-evident audit trail — runtime governance at the write boundary, not alignment/ethics theory.

### Quality bar
- [x] Publicly accessible — open article, no paywall, no sign-up
- [x] Link verified working (HTTP 200, no redirect)
- [x] Alphabetical order preserved within the section
- [x] Factual description — no marketing language, no performance/benchmark claims
- [x] Single entry in this PR

### Disclosure
I work on Penholder (built on AnyChart's spreadsheet engine), submitting from the AnyChart org. The wording is deliberately neutral — happy to adjust it or drop the entry if it isn't a fit. If you'd prefer it under **Learning Resources**, that works too.
