### PR TITLE
docs: exclude pre-merge CI gates from scope explicitly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Contributions welcome. This list covers **runtime governance of AI agents** — 
 
 - General AI safety or alignment research
 - AI ethics principles or governance manifestos (without tooling)
+- CI/CD gates over AI-generated code (pre-merge, not runtime)
 - Courses or tutorials on building agents (without governance focus)
 - Vendor marketing content without a substantive free tier or open-source component
 


### PR DESCRIPTION
The line you asked for in #33, under *What does not belong here*:

> CI/CD gates over AI-generated code (pre-merge, not runtime)

One line, wording as you specified. Placed between the manifestos line and the courses line.

The architecture pattern write-up is in progress and will come as its own submission once it is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)