### PR TITLE
docs: add least-privilege-as-import-contract pattern write-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Interactive tools that answer common governance questions without a signup. Each
 - [Anthropic: Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) - Anthropic's published guidance on safe agentic systems: minimal footprint, human-in-the-loop for high-stakes actions, and preference for reversible over irreversible actions.
 - [awesome-agentic-patterns](https://github.com/nibzard/awesome-agentic-patterns) - Curated collection of production agent patterns including sandboxing, credential management, human-in-the-loop workflows, and multi-agent coordination.
 - [HumanLayer](https://github.com/humanlayer/humanlayer) - SDK for building human-in-the-loop workflows for AI agents. Wraps tool calls with approval gates, audit trails, and escalation paths.
+- [Least privilege as an import contract](https://github.com/chohan-sarmad-ali/delivery-case-studies/blob/main/05-least-privilege-as-an-import-contract.md) - Single-egress architecture for agent systems: all outbound calls originate from one package behind policy checks and mandatory human approval, an import-linter contract enforced in CI keeps it single, and a static AST gate closes the authorisation gap the import contract cannot see. Includes the incident that motivated the layering and the limits of each layer.
 - [Lilian Weng: LLM-Powered Autonomous Agents](https://lilianweng.github.io/posts/2023-06-23-agent/) - Comprehensive survey of agent architectures including planning, memory, tool use, and oversight mechanisms.
 
 ---


### PR DESCRIPTION
The write-up from #33, submitted as agreed: the pattern, not the tool.

Placed alphabetically in *Agentic Architecture Patterns*. It leads on the enforcement point you named (least privilege as a build-time import contract, so the constraint fails CI instead of depending on a policy engine being consulted at call time) and states the limits plainly: the contract binds the import graph and nothing else, the tool could not see one external namespace and a source-reading test covers it, and the contract file itself is protected procedurally, not mechanically. The centre of the piece is the day the import contract was not enough.

Disclosure: I am the author of the write-up and I run the system it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)