### PR TITLE
docs: add aGiTrack to Audit, Observability, and Cost Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Interactive tools that answer common governance questions without a signup. Each
 
 ## Audit, Observability, and Cost Control
 
+- [aGiTrack](https://github.com/core-aix/agitrack) - Runtime audit trail for terminal coding agents. Wraps Claude Code, Codex, or OpenCode and commits each agent turn to git, recording the prompt, backend, model, and that turn's input, output, cache-read, and cache-write token counts in the commit message, so the trace lives in version control rather than a separate log store. Sub-agent tokens are counted separately. Apache-2.0.
 - [CausalLayer MCP](https://github.com/smq9sn5jck-coder/causallayer-mcp) - Deterministic AI liability attribution engine exposed as a remote MCP server. Given a structured incident, returns a CausalCertificateV1: a signed, hash-chained, Bitcoin-anchored receipt allocating fault between AI vendor, deployer, and end-user. Four-factor scoring, Shapley-inspired multi-agent attribution, and jurisdiction-aware regulatory mapping (EU AI Act, NIST AI RMF, AU AI Ethics).
 - [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) - Open-source live-web benchmark for evaluating browser and computer-use agents on 283 tasks across 163 websites, with request interception and execution evidence useful for governance audits.
 - [Clay Seal Receipts](https://github.com/clayseal/clayseal-receipts) - Verifiable execution receipts for AI agent actions: policy wrap with shadow mode, signed offline-verifiable receipts so audit trails do not depend on the vendor being online. MIT.


### PR DESCRIPTION
Adds aGiTrack to **Audit, Observability, and Cost Control**, in alphabetical order within the section.

**Author disclosure:** I wrote aGiTrack, disclosed here per CONTRIBUTING.

### What it is

aGiTrack (Apache-2.0, Python) wraps a terminal coding agent (Claude Code, Codex, or OpenCode) and commits each agent turn to git as it happens. The commit message carries an `# aGiTrack Metadata` block with the backend, model, reasoning effort, session ids, start/end timestamps, and that turn's `tokens_since_last_commit_input` / `_output` / `_cache_read` / `_cache_write`, with sub-agent spend counted separately.

The design point relative to the existing entries in this section: the audit record is the git history itself, not a sidecar log store or a receipt service. `git log` answers what an agent changed, under which model, at what token cost, and the record moves with the repository.

### Scope check against CONTRIBUTING

- **In scope** as an "audit, observability, and cost tracking tool for agent systems": the trail is written at agent runtime, per turn.
- **Not** a CI/CD gate over AI-generated code. It records while the agent works; nothing runs pre-merge and nothing blocks a merge.
- **Publicly accessible:** open source, Apache-2.0, on PyPI as `agitrack`.
- **Actively maintained:** commits this week, currently v0.6.16.
- **Factual description:** no performance claims. Every element of the entry is visible in the commit trailers of the repo's own history, e.g. [`c6258c25`](https://github.com/core-aix/agitrack/commit/c6258c25).

### Caveats stated plainly

Attribution is per turn and per diff, not per line. There is no cryptographic signing or hash-chaining, so this is a development-time provenance record, not tamper-evident evidence in the sense of the receipt-based entries alongside it.