### PR TITLE
Add Agentic Control Plane to Claude Code and MCP Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Interactive tools that answer common governance questions without a signup. Each
 ## Claude Code and MCP Governance
 
 - [agent-approval-gate](https://github.com/Prime-agentai/agent-approval-gate) - PreToolUse hook enforcing spend, account-creation, and fund-movement gates for autonomous agents. Blocked calls become queued approval tickets; includes an installer and a probe-based verifier for both block and allow paths.
+- [Agentic Control Plane](https://github.com/agentic-control-plane/acp-install) - Policy enforcement on every tool call across Claude Code, Codex, Cursor, and MCP clients from one install. Allow, ask, or deny before execution; per-agent and per-workspace spend caps; PII redaction; and an audit trail that resolves each call back to the human who started the run. MIT open core ([GatewayStack](https://github.com/agentic-control-plane/GatewayStack)); runs hosted or fully local.
 - [Anthropic Cookbook](https://github.com/anthropics/anthropic-cookbook) - Reference implementations and patterns from Anthropic including agent architectures, tool use, and safety patterns.
 - [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) - The canonical Claude Code community list covering tooling, hooks, slash-commands, agent skills, and workflows.
 - [awesome-claude-code-security](https://github.com/efij/awesome-claude-code-security) - Curated list focused on Claude Code hardening: MCP server security, secrets scanning, prompt injection detection, and red-teaming frameworks.


### PR DESCRIPTION
Adds Agentic Control Plane to *Claude Code and MCP Governance*, alphabetically between `agent-approval-gate` and *Anthropic Cookbook*.

Runtime enforcement, not a pre-merge CI gate: a policy check runs on every tool call before execution across Claude Code, Codex, Cursor, Antigravity, and MCP clients, returning allow/ask/deny. Adds per-agent and per-workspace spend caps, PII redaction, and an audit trail that resolves each call back to the originating human across delegation chains.

MIT open core (GatewayStack); runs hosted or fully local. We also publish ADCS, an open spec for agent-to-agent delegation chains, and AgentGovBench, a 48-scenario benchmark for identity/policy/observability across agent runtimes — happy to add either separately if they fit.

Disclosure: I maintain Agentic Control Plane.